### PR TITLE
Add Jest tests for Node.js Express backend routes

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
     "scripts": {
         "dev": "nodemon dist/app.js",
         "build": "tsc",
-        "format": "prettier --write \"src/**/*.ts\""
+        "format": "prettier --write \"src/**/*.ts\"",
+        "test": "jest"
     },
     "author": "",
     "license": "ISC",
@@ -32,7 +33,10 @@
         "prettier": "^3.4.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.2",
-        "typescript-eslint": "^8.18.1"
+        "typescript-eslint": "^8.18.1",
+        "jest": "^29.0.0",
+        "@types/jest": "^29.0.0",
+        "supertest": "^6.2.3"
     },
     "dependencies": {
         "@types/multer": "^1.4.12",

--- a/backend/src/tests/fileRoutes.test.ts
+++ b/backend/src/tests/fileRoutes.test.ts
@@ -1,0 +1,191 @@
+import request from 'supertest';
+import express from 'express';
+import fileRoutes from '../router/file';
+import { fileModel } from '../models/fileModel';
+import { authorizationMiddleware } from '../middleware/auth';
+import { fileUploadMiddlware } from '../middleware/fileUpload';
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/files', fileRoutes);
+
+jest.mock('../models/fileModel');
+jest.mock('../middleware/auth');
+jest.mock('../middleware/fileUpload');
+
+describe('File Routes', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('GET /:groupId/groupfiles', () => {
+        it('should return files for a group', async () => {
+            const mockFiles = [{ fileName: 'file1' }, { fileName: 'file2' }];
+            fileModel.find.mockResolvedValue(mockFiles);
+
+            const response = await request(app).get('/api/v1/files/123/groupfiles');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockFiles);
+        });
+
+        it('should return 401 if groupId is missing', async () => {
+            const response = await request(app).get('/api/v1/files//groupfiles');
+
+            expect(response.status).toBe(401);
+            expect(response.body.message).toBe('Unauthorized');
+        });
+    });
+
+    describe('POST /:groupId/upload', () => {
+        it('should upload a file', async () => {
+            const mockFile = {
+                filename: 'file1',
+                size: 1000,
+                mimetype: 'image/png',
+                destination: 'uploads'
+            };
+            const mockUser = { userId: '123' };
+            const mockGroup = { groupId: '456' };
+            const mockNewFile = { fileName: 'file1', fileType: 'image/png', fileSize: 1000, fileUrl: 'uploads/file1', userId: '123', groupId: '456' };
+
+            fileUploadMiddlware.mockImplementation(() => (req, res, next) => {
+                req.file = mockFile;
+                next();
+            });
+
+            authorizationMiddleware.mockImplementation((req, res, next) => {
+                req.customData = mockUser;
+                next();
+            });
+
+            fileModel.create.mockResolvedValue(mockNewFile);
+
+            const response = await request(app)
+                .post('/api/v1/files/456/upload')
+                .attach('file', Buffer.from('file content'), 'file1.png');
+
+            expect(response.status).toBe(201);
+            expect(response.body.msg).toEqual(mockNewFile);
+        });
+
+        it('should return 401 if userId or groupId is missing', async () => {
+            const response = await request(app).post('/api/v1/files//upload');
+
+            expect(response.status).toBe(401);
+            expect(response.body.message).toBe('Unauthorized');
+        });
+    });
+
+    describe('GET /search', () => {
+        it('should search files', async () => {
+            const mockFiles = [{ fileName: 'file1' }, { fileName: 'file2' }];
+            fileModel.find.mockResolvedValue(mockFiles);
+
+            const response = await request(app).get('/api/v1/files/search?searchquery=test');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockFiles);
+        });
+
+        it('should return 400 if search query is missing', async () => {
+            const response = await request(app).get('/api/v1/files/search');
+
+            expect(response.status).toBe(400);
+            expect(response.body.msg).toBe('Search query is missing');
+        });
+    });
+
+    describe('GET /:fileId', () => {
+        it('should return file by id', async () => {
+            const mockFile = { fileName: 'file1' };
+            fileModel.findById.mockResolvedValue(mockFile);
+
+            const response = await request(app).get('/api/v1/files/123');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockFile);
+        });
+
+        it('should return 400 if fileId is missing', async () => {
+            const response = await request(app).get('/api/v1/files/');
+
+            expect(response.status).toBe(400);
+            expect(response.body.msg).toBe('FileId is missing');
+        });
+    });
+
+    describe('GET /:fileId/download', () => {
+        it('should download file by id', async () => {
+            const mockFile = { fileUrl: 'uploads/file1.png' };
+            fileModel.findById.mockResolvedValue(mockFile);
+
+            const response = await request(app).get('/api/v1/files/123/download');
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should return 400 if fileId is missing', async () => {
+            const response = await request(app).get('/api/v1/files//download');
+
+            expect(response.status).toBe(400);
+            expect(response.body.msg).toBe('FileId is missing');
+        });
+    });
+
+    describe('DELETE /:fileId/delete', () => {
+        it('should delete file by id', async () => {
+            const mockUser = { userId: '123' };
+            const mockFile = { fileId: '456', userId: '123' };
+
+            authorizationMiddleware.mockImplementation((req, res, next) => {
+                req.customData = mockUser;
+                next();
+            });
+
+            fileModel.findOneAndDelete.mockResolvedValue(mockFile);
+
+            const response = await request(app).delete('/api/v1/files/456/delete');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toBe('File successfully deleted');
+        });
+
+        it('should return 400 if fileId is missing', async () => {
+            const response = await request(app).delete('/api/v1/files//delete');
+
+            expect(response.status).toBe(400);
+            expect(response.body.msg).toBe('FileId is missing');
+        });
+    });
+
+    describe('PATCH /:fileId/updatefile', () => {
+        it('should update file metadata', async () => {
+            const mockUser = { userId: '123' };
+            const mockFile = { _id: '456', userId: '123' };
+            const mockUpdatedFile = { fileName: 'updatedFile' };
+
+            authorizationMiddleware.mockImplementation((req, res, next) => {
+                req.customData = mockUser;
+                next();
+            });
+
+            fileModel.findOne.mockResolvedValue(mockFile);
+            fileModel.findOneAndUpdate.mockResolvedValue(mockUpdatedFile);
+
+            const response = await request(app)
+                .patch('/api/v1/files/456/updatefile')
+                .send({ fileName: 'updatedFile' });
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockUpdatedFile);
+        });
+
+        it('should return 400 if fileId is missing', async () => {
+            const response = await request(app).patch('/api/v1/files//updatefile');
+
+            expect(response.status).toBe(400);
+            expect(response.body.msg).toBe('FileId is missing');
+        });
+    });
+});

--- a/backend/src/tests/friendRoutes.test.ts
+++ b/backend/src/tests/friendRoutes.test.ts
@@ -1,0 +1,78 @@
+import request from 'supertest';
+import app from '../app';
+import { friendsModel } from '../models/friendsModel';
+import { getFriends, getFriend, addFriend, deleteFriend, changeFriendStatus } from '../controllers/friendsController';
+import { authorizationMiddleware } from '../middleware/auth';
+
+jest.mock('../models/friendsModel');
+
+describe('Friend Routes', () => {
+  let server: any;
+
+  beforeAll(() => {
+    server = app.listen(4000);
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  describe('GET /friends', () => {
+    it('should get all friends', async () => {
+      const friends = [{ friendId: 'friend1' }, { friendId: 'friend2' }];
+      (friendsModel.find as jest.Mock).mockResolvedValue(friends);
+
+      const response = await request(server).get('/friends');
+
+      expect(response.status).toBe(200);
+      expect(response.body.msg).toEqual(friends);
+    });
+  });
+
+  describe('GET /friends/:friendId', () => {
+    it('should get friend by id', async () => {
+      const friend = { friendId: 'friend1' };
+      (friendsModel.findOne as jest.Mock).mockResolvedValue(friend);
+
+      const response = await request(server).get('/friends/friend1');
+
+      expect(response.status).toBe(200);
+      expect(response.body.msg).toEqual(friend);
+    });
+  });
+
+  describe('POST /friends', () => {
+    it('should add a new friend', async () => {
+      const newFriend = { friendId: 'friend1' };
+      (friendsModel.create as jest.Mock).mockResolvedValue(newFriend);
+
+      const response = await request(server).post('/friends').send(newFriend);
+
+      expect(response.status).toBe(200);
+      expect(response.body.msg).toEqual(newFriend);
+    });
+  });
+
+  describe('DELETE /friends/:friendId', () => {
+    it('should delete friend by id', async () => {
+      (friendsModel.deleteOne as jest.Mock).mockResolvedValue({});
+
+      const response = await request(server).delete('/friends/friend1');
+
+      expect(response.status).toBe(200);
+      expect(response.body.msg).toBe('Friend deleted!');
+    });
+  });
+
+  describe('PATCH /friends/:friendId', () => {
+    it('should change friend status', async () => {
+      const updatedFriend = { friendId: 'friend1', status: 'accepted' };
+      (friendsModel.findOneAndUpdate as jest.Mock).mockResolvedValue(updatedFriend);
+
+      const response = await request(server).patch('/friends/friend1').send({ status: 'accepted' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.msg).toBe('Friend status changed for both users!');
+    });
+  });
+});

--- a/backend/src/tests/groupRoutes.test.ts
+++ b/backend/src/tests/groupRoutes.test.ts
@@ -1,0 +1,182 @@
+import request from 'supertest';
+import express from 'express';
+import { groupModel } from '../models/groupModel';
+import { userModel } from '../models/userModel';
+import { authorizationMiddleware } from '../middleware/auth';
+import groupRoutes from '../router/groups';
+
+const app = express();
+app.use(express.json());
+app.use('/groups', groupRoutes);
+
+jest.mock('../models/groupModel');
+jest.mock('../models/userModel');
+jest.mock('../middleware/auth');
+
+describe('Group Routes', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('GET /groups', () => {
+        it('should return all groups', async () => {
+            const mockGroups = [{ name: 'Group 1' }, { name: 'Group 2' }];
+            groupModel.find.mockResolvedValue(mockGroups);
+
+            const response = await request(app).get('/groups');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockGroups);
+        });
+
+        it('should handle errors', async () => {
+            groupModel.find.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app).get('/groups');
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('GET /groups/:groupId', () => {
+        it('should return a group by ID', async () => {
+            const mockGroup = { name: 'Group 1' };
+            groupModel.findById.mockResolvedValue(mockGroup);
+
+            const response = await request(app).get('/groups/1');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockGroup);
+        });
+
+        it('should handle errors', async () => {
+            groupModel.findById.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app).get('/groups/1');
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('POST /groups', () => {
+        it('should create a new group', async () => {
+            const mockGroup = { name: 'Group 1' };
+            groupModel.create.mockResolvedValue(mockGroup);
+
+            const response = await request(app)
+                .post('/groups')
+                .send({ name: 'Group 1' });
+
+            expect(response.status).toBe(201);
+            expect(response.body.msg).toEqual(mockGroup);
+        });
+
+        it('should handle errors', async () => {
+            groupModel.create.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app)
+                .post('/groups')
+                .send({ name: 'Group 1' });
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('POST /groups/:groupId/join', () => {
+        it('should join a group', async () => {
+            const mockGroup = { name: 'Group 1', usersId: [] };
+            const mockUser = { _id: '1' };
+            groupModel.findById.mockResolvedValue(mockGroup);
+            userModel.findById.mockResolvedValue(mockUser);
+            groupModel.prototype.save.mockResolvedValue();
+
+            const response = await request(app)
+                .post('/groups/1/join')
+                .send({ userId: '1' });
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockGroup);
+        });
+
+        it('should handle errors', async () => {
+            groupModel.findById.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app)
+                .post('/groups/1/join')
+                .send({ userId: '1' });
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('DELETE /groups/:groupId', () => {
+        it('should delete a group', async () => {
+            groupModel.findByIdAndDelete.mockResolvedValue();
+
+            const response = await request(app).delete('/groups/1');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toBe('Group deleted successfully');
+        });
+
+        it('should handle errors', async () => {
+            groupModel.findByIdAndDelete.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app).delete('/groups/1');
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('PATCH /groups/:groupId', () => {
+        it('should update a group', async () => {
+            const mockGroup = { name: 'Updated Group' };
+            groupModel.findByIdAndUpdate.mockResolvedValue(mockGroup);
+
+            const response = await request(app)
+                .patch('/groups/1')
+                .send({ name: 'Updated Group' });
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockGroup);
+        });
+
+        it('should handle errors', async () => {
+            groupModel.findByIdAndUpdate.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app)
+                .patch('/groups/1')
+                .send({ name: 'Updated Group' });
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('DELETE /groups/:groupId/members/:userId', () => {
+        it('should remove a user from a group', async () => {
+            const mockGroup = { name: 'Group 1', usersId: ['1'] };
+            groupModel.findById.mockResolvedValue(mockGroup);
+            groupModel.prototype.save.mockResolvedValue();
+
+            const response = await request(app).delete('/groups/1/members/1');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockGroup);
+        });
+
+        it('should handle errors', async () => {
+            groupModel.findById.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app).delete('/groups/1/members/1');
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+});

--- a/backend/src/tests/messageRoutes.test.ts
+++ b/backend/src/tests/messageRoutes.test.ts
@@ -1,0 +1,62 @@
+import request from 'supertest';
+import express from 'express';
+import { messageModel } from '../models/messageModel';
+import messageRoutes from '../router/message';
+
+const app = express();
+app.use(express.json());
+app.use('/messages', messageRoutes);
+
+jest.mock('../models/messageModel');
+
+describe('Message Routes', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('GET /messages', () => {
+        it('should return all messages', async () => {
+            const mockMessages = [{ message: 'Hello' }, { message: 'Hi' }];
+            messageModel.find.mockResolvedValue(mockMessages);
+
+            const response = await request(app).get('/messages');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual(mockMessages);
+        });
+
+        it('should handle errors', async () => {
+            messageModel.find.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app).get('/messages');
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('POST /messages', () => {
+        it('should create a new message', async () => {
+            const mockMessage = { message: 'Hello' };
+            messageModel.create.mockResolvedValue(mockMessage);
+
+            const response = await request(app)
+                .post('/messages')
+                .send({ message: 'Hello', userId: '1', groupId: '1' });
+
+            expect(response.status).toBe(201);
+            expect(response.body).toEqual(mockMessage);
+        });
+
+        it('should handle errors', async () => {
+            messageModel.create.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app)
+                .post('/messages')
+                .send({ message: 'Hello', userId: '1', groupId: '1' });
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+});

--- a/backend/src/tests/taskRoutes.test.ts
+++ b/backend/src/tests/taskRoutes.test.ts
@@ -1,0 +1,130 @@
+import request from 'supertest';
+import express from 'express';
+import { taskModel } from '../models/taskModel';
+import { authorizationMiddleware } from '../middleware/auth';
+import taskRoutes from '../router/task';
+
+const app = express();
+app.use(express.json());
+app.use('/tasks', taskRoutes);
+
+jest.mock('../models/taskModel');
+jest.mock('../middleware/auth');
+
+describe('Task Routes', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('GET /tasks', () => {
+        it('should return all tasks for authenticated user', async () => {
+            const mockTasks = [{ title: 'Task 1' }, { title: 'Task 2' }];
+            taskModel.find.mockResolvedValue(mockTasks);
+
+            const response = await request(app).get('/tasks');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockTasks);
+        });
+
+        it('should handle errors', async () => {
+            taskModel.find.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app).get('/tasks');
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('GET /tasks/:taskId', () => {
+        it('should return a task by ID for authenticated user', async () => {
+            const mockTask = { title: 'Task 1' };
+            taskModel.findOne.mockResolvedValue(mockTask);
+
+            const response = await request(app).get('/tasks/1');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockTask);
+        });
+
+        it('should handle errors', async () => {
+            taskModel.findOne.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app).get('/tasks/1');
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('POST /tasks', () => {
+        it('should create a new task for authenticated user', async () => {
+            const mockTask = { title: 'Task 1' };
+            taskModel.create.mockResolvedValue(mockTask);
+
+            const response = await request(app)
+                .post('/tasks')
+                .send({ title: 'Task 1', description: 'Task description', status: 'pending' });
+
+            expect(response.status).toBe(201);
+            expect(response.body.msg).toEqual(mockTask);
+        });
+
+        it('should handle errors', async () => {
+            taskModel.create.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app)
+                .post('/tasks')
+                .send({ title: 'Task 1', description: 'Task description', status: 'pending' });
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('PATCH /tasks/:taskId', () => {
+        it('should update a task for authenticated user', async () => {
+            const mockTask = { title: 'Updated Task' };
+            taskModel.findOneAndUpdate.mockResolvedValue(mockTask);
+
+            const response = await request(app)
+                .patch('/tasks/1')
+                .send({ title: 'Updated Task' });
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual(mockTask);
+        });
+
+        it('should handle errors', async () => {
+            taskModel.findOneAndUpdate.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app)
+                .patch('/tasks/1')
+                .send({ title: 'Updated Task' });
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+
+    describe('DELETE /tasks/:taskId', () => {
+        it('should delete a task for authenticated user', async () => {
+            taskModel.findOneAndDelete.mockResolvedValue();
+
+            const response = await request(app).delete('/tasks/1');
+
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toBe('Task successfully deleted');
+        });
+
+        it('should handle errors', async () => {
+            taskModel.findOneAndDelete.mockRejectedValue(new Error('Database error'));
+
+            const response = await request(app).delete('/tasks/1');
+
+            expect(response.status).toBe(500);
+            expect(response.body.msg).toBe('Database error');
+        });
+    });
+});

--- a/backend/src/tests/userRoutes.test.ts
+++ b/backend/src/tests/userRoutes.test.ts
@@ -1,0 +1,169 @@
+import request from 'supertest';
+import app from '../app';
+import { userModel } from '../models/userModel';
+import { tokenModel } from '../models/tokenModel';
+import { blacklistTokenModel } from '../models/blacklistTokens';
+import { signUp, signIn, refreshToken, logoutController, getUserController, getUserByIdController, deleteUserController, patchUserController } from '../controllers/userController';
+import { signInAuth } from '../middleware/signInAuth';
+import { authorizationMiddleware } from '../middleware/auth';
+
+jest.mock('../models/userModel');
+jest.mock('../models/tokenModel');
+jest.mock('../models/blacklistTokens');
+
+describe('User Routes', () => {
+  let server: any;
+
+  beforeAll(() => {
+    server = app.listen(4000);
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  describe('POST /signup', () => {
+    it('should sign up a new user', async () => {
+      const newUser = { email: 'test@example.com', password: 'password123' };
+      (userModel.create as jest.Mock).mockResolvedValue(newUser);
+
+      const response = await request(server).post('/signup').send(newUser);
+
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual(newUser);
+    });
+
+    it('should return 400 if email is already used', async () => {
+      const newUser = { email: 'test@example.com', password: 'password123' };
+      (userModel.findOne as jest.Mock).mockResolvedValue(newUser);
+
+      const response = await request(server).post('/signup').send(newUser);
+
+      expect(response.status).toBe(400);
+      expect(response.body.msg).toBe('Email is already used!');
+    });
+  });
+
+  describe('POST /signin', () => {
+    it('should sign in a user', async () => {
+      const user = { email: 'test@example.com', password: 'password123' };
+      const token = 'some-token';
+      (signInAuth as jest.Mock).mockImplementation((req, res, next) => {
+        req.customData = { token };
+        next();
+      });
+      (userModel.findOne as jest.Mock).mockResolvedValue(user);
+
+      const response = await request(server).post('/signin').send(user);
+
+      expect(response.status).toBe(200);
+      expect(response.body.token).toBe(token);
+    });
+
+    it('should return 401 if credentials are invalid', async () => {
+      const user = { email: 'test@example.com', password: 'wrongpassword' };
+      (userModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      const response = await request(server).post('/signin').send(user);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Invalid credentials');
+    });
+  });
+
+  describe('GET /refresh', () => {
+    it('should refresh token', async () => {
+      const refreshToken = 'some-refresh-token';
+      const newAccessToken = 'new-access-token';
+      (tokenModel.create as jest.Mock).mockResolvedValue({ token: refreshToken });
+      (userModel.findById as jest.Mock).mockResolvedValue({ _id: 'user-id' });
+
+      const response = await request(server).get('/refresh').set('RefreshToken', refreshToken);
+
+      expect(response.status).toBe(200);
+      expect(response.body.newAccessToken).toBe(newAccessToken);
+    });
+
+    it('should return 401 if refresh token is missing', async () => {
+      const response = await request(server).get('/refresh');
+
+      expect(response.status).toBe(401);
+      expect(response.body.msg).toBe('Access denied');
+    });
+  });
+
+  describe('GET /logout', () => {
+    it('should log out a user', async () => {
+      const refreshToken = 'some-refresh-token';
+      (tokenModel.findOneAndDelete as jest.Mock).mockResolvedValue({ token: refreshToken });
+      (blacklistTokenModel.create as jest.Mock).mockResolvedValue({ token: refreshToken });
+
+      const response = await request(server).get('/logout').set('Cookie', `refreshToken=${refreshToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.msg).toBe('User logged out successfully');
+    });
+
+    it('should return 204 if refresh token is missing', async () => {
+      const response = await request(server).get('/logout');
+
+      expect(response.status).toBe(204);
+    });
+  });
+
+  describe('GET /', () => {
+    it('should get all users', async () => {
+      const users = [{ email: 'test1@example.com' }, { email: 'test2@example.com' }];
+      (userModel.find as jest.Mock).mockResolvedValue(users);
+
+      const response = await request(server).get('/');
+
+      expect(response.status).toBe(200);
+      expect(response.body.msg).toEqual(users);
+    });
+  });
+
+  describe('GET /:id', () => {
+    it('should get user by id', async () => {
+      const user = { email: 'test@example.com' };
+      (userModel.findById as jest.Mock).mockResolvedValue(user);
+
+      const response = await request(server).get('/123');
+
+      expect(response.status).toBe(200);
+      expect(response.body.msg).toEqual(user);
+    });
+  });
+
+  describe('DELETE /:id', () => {
+    it('should delete user by id', async () => {
+      (userModel.findByIdAndDelete as jest.Mock).mockResolvedValue({});
+
+      const response = await request(server).delete('/123');
+
+      expect(response.status).toBe(200);
+      expect(response.body.msg).toBe('User deleted successfully');
+    });
+
+    it('should return 404 if user not found', async () => {
+      (userModel.findByIdAndDelete as jest.Mock).mockResolvedValue(null);
+
+      const response = await request(server).delete('/123');
+
+      expect(response.status).toBe(404);
+      expect(response.body.msg).toBe('User not found');
+    });
+  });
+
+  describe('PATCH /:id', () => {
+    it('should update user by id', async () => {
+      const updatedUser = { email: 'updated@example.com' };
+      (userModel.findByIdAndUpdate as jest.Mock).mockResolvedValue(updatedUser);
+
+      const response = await request(server).patch('/123').send(updatedUser);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(updatedUser);
+    });
+  });
+});


### PR DESCRIPTION
Add Jest tests for Node.js Express backend routes.

* **User Routes Tests**: Add tests for `/signup`, `/signin`, `/refresh`, `/logout`, `/`, `/:id`, `/:id` delete, and `/:id` patch routes in `backend/src/tests/userRoutes.test.ts`.
* **Group Routes Tests**: Add tests for `/`, `/:groupId`, `/` post, `/:groupId/join`, `/:groupId` delete, `/:groupId` patch, and `/:groupId/members/:userId` delete routes in `backend/src/tests/groupRoutes.test.ts`.
* **Message Routes Tests**: Add tests for `/` get and post routes in `backend/src/tests/messageRoutes.test.ts`.
* **Task Routes Tests**: Add tests for `/`, `/:taskId`, `/` post, `/:taskId` patch, and `/:taskId` delete routes in `backend/src/tests/taskRoutes.test.ts`.
* **File Routes Tests**: Add tests for `/:groupId/groupfiles`, `/:groupId/upload`, `/search`, `/:fileId`, `/:fileId/download`, `/:fileId/delete`, and `/:fileId/updatefile` routes in `backend/src/tests/fileRoutes.test.ts`.
* **Package.json**: Add `test` script to run Jest tests and add necessary Jest and Supertest dependencies in `backend/package.json`.

